### PR TITLE
Updated exports for Bannerbear class

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ yarn add bannerbear
 
 ## Usage
 
+### Import
+In Javascript
+```js
+const Bannerbear = require('bannerbear')
+```
+
+And in typescript
+```ts
+import Bannerbear from 'bannerbear';
+```
+
 ### Authentication
 
 instantiate

--- a/src/bannerbear.ts
+++ b/src/bannerbear.ts
@@ -168,7 +168,7 @@ export interface Account {
   current_project: any;
 }
 
-export default class Bannerbear {
+export class Bannerbear {
   private api;
   private syncApi;
   private token: string;
@@ -381,3 +381,5 @@ export default class Bannerbear {
     return `${base}${query}&s=${signature}`
   }
 }
+
+export default Bannerbear;


### PR DESCRIPTION
Updated so you can import via require and import without use of `default`

```ts
import Bannerbear from 'bannerbear';
```


```js
const Bannerbear = require('bannerbear')
```