### PR TITLE
Possible change - Have clearer description in the Import section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ yarn add bannerbear
 - [Signed URLs](#signed-urls)
 
 ### Import
-In Javascript
+In the backend (Node)
 ```js
 const { Bannerbear } = require('bannerbear')
 ```
 
-And in typescript
+And in the frontend (TypeScript)
 ```ts
 import Bannerbear from 'bannerbear';
 ```


### PR DESCRIPTION
Hi guys, would my edit be fair enough? Small change but I think it would be more correct. 

Technically they both can be described as JavaScript (or TypeScript), but from my understanding, the top one with `require` would be used in NodeJS (as in the backend with like Express.js), while the `import` would be used on the client side. Always learning - please let me know 🙂 Cheers. 