### PR TITLE
Readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ import Bannerbear from 'bannerbear';
 
 ### Authentication
 
-instantiate
 Get the API key for your project in Bannerbear and then instantiate a new client.
 
 ```ts


### PR DESCRIPTION
Removed an extra "instantiate" that seemed out of place.

Or maybe it was supposed to be there? Just ignore me if so! 🙂 